### PR TITLE
fixed workouts refresh bug

### DIFF
--- a/src/components/WorkoutCard.js
+++ b/src/components/WorkoutCard.js
@@ -13,6 +13,7 @@ import {
   ModalFooter
 } from 'reactstrap';
 import { deleteWorkoutCoach } from '../helpers/data/workoutsData';
+import { seeWorkoutsForRace } from '../helpers/data/raceWorkoutsData';
 import WorkoutsForm from './WorkoutsForm';
 import QuickWorkout from './QuickWorkout';
 
@@ -33,7 +34,7 @@ function WorkoutCard({
         setEditWorkout((prevState) => !prevState);
         break;
       case 'delete':
-        deleteWorkoutCoach(workoutInfo.firebaseKey, coach.coachUid).then((workoutArray) => setRaceWorkout(workoutArray));
+        deleteWorkoutCoach(workoutInfo.firebaseKey, coach.coachUid).then(() => seeWorkoutsForRace(workoutInfo.raceId).then((workoutArray) => setRaceWorkout(workoutArray.workout)));
         break;
       default:
         console.warn('Keep Being Awesome!');
@@ -64,10 +65,12 @@ function WorkoutCard({
           <CardText>{workoutInfo.actualWork}</CardText>
           <CardText>{workoutInfo.totalMiles}</CardText>
           <CardText>{workoutInfo.averagePace}</CardText>
-          <Button onClick={toggle}>Short on Time</Button>
+          { coach
+            ? ''
+            : <Button onClick={toggle}>Short on Time</Button> }
           {coach
             ? <Button color='danger' onClick={() => handleClick('delete')}>
-              Coach Delete</Button> : ''}
+              Delete Workout </Button> : ''}
           <Button color='warning' onClick={() => handleClick('edit')}>
             { editWorkout ? 'Close Form' : 'Edit Workout'}
           </Button>

--- a/src/components/WorkoutsForm.js
+++ b/src/components/WorkoutsForm.js
@@ -14,6 +14,7 @@ import {
 } from '../helpers/data/workoutsData';
 import { getAthletes } from '../helpers/data/athleteData';
 import { getAllRaces } from '../helpers/data/raceData';
+import { seeWorkoutsForRace } from '../helpers/data/raceWorkoutsData';
 
 function WorkoutsForm({
   coach, athlete, setWorkouts, formTitle, setRaceWorkout, setEditWorkout, ...workoutInfo
@@ -49,18 +50,20 @@ function WorkoutsForm({
     }));
   };
 
+  // deleteWorkoutCoach(workoutInfo.firebaseKey, coach.coachUid).then(() => seeWorkoutsForRace(workoutInfo.raceId).then((workoutArray) => setRaceWorkout(workoutArray.workout)));
+
   const handleSubmit = (e) => {
     e.preventDefault();
     if (addWorkouts.firebaseKey && workoutInfo.coachUid && workoutInfo.athleteUid) {
-      updateWorkoutCoach(addWorkouts, workoutInfo.coachUid).then((workoutArray) => {
-        setRaceWorkout(workoutArray);
+      updateWorkoutCoach(addWorkouts, workoutInfo.coachUid).then(() => seeWorkoutsForRace(workoutInfo.raceId).then((workoutArray) => {
+        setRaceWorkout(workoutArray.workout);
         setEditWorkout(false);
-      });
+      }));
     } else if (addWorkouts.firebaseKey && workoutInfo.athleteUid && workoutInfo.coachUid) {
-      updateWorkoutAthlete(addWorkouts, workoutInfo.athleteUid).then((workoutArray) => {
-        setRaceWorkout(workoutArray);
+      updateWorkoutAthlete(addWorkouts, workoutInfo.athleteUid).then(() => seeWorkoutsForRace(workoutInfo.raceId).then((workoutArray) => {
+        setRaceWorkout(workoutArray.workout);
         setEditWorkout(false);
-      });
+      }));
     } else if (coach !== null) {
       addWorkoutCoach(addWorkouts, workoutInfo.coachUid).then((workoutArray) => {
         setAddWorkouts(workoutArray);


### PR DESCRIPTION
When editing or deleting a workout, all the workouts for all races then showed on the DOM. Fixed the bug, so that when editing (coach or athlete) and deleting (coach only), only the workouts for that specific race appear.

Made it so only the athlete can see the button for the quick workout modal, since the coach can see all quick workouts in the add/edit view.